### PR TITLE
fix: Provisioning crash due to invalid type value returned

### DIFF
--- a/example.py
+++ b/example.py
@@ -123,6 +123,8 @@ def write_request(
         if target_uuid != None and target_value != None:
             logging.debug(
                 f"Setting {ImprovUUID(target_uuid)} to {target_value}")
+            if isinstance(target_value, list):
+                target_value = target_value[0]
             server.get_characteristic(
                 target_uuid,
             ).value = target_value


### PR DESCRIPTION
Returned value is a `list`, expected value is `bytearray`.
This fixes the error raised.

<details>
<summary>Log</summary>

```python
DEBUG:root:Setting ImprovUUID.RPC_RESULT_UUID to [bytearray(b'\x01\x15\x14http://192.168.2.123\x0f')]
ERROR:root:got unexpected error processing a message: 'bytearray' object cannot be interpreted as an integer.
Traceback (most recent call last):
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/dbus_next/message_bus.py", line 621, in _on_message
    self._process_message(msg)
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/dbus_next/message_bus.py", line 712, in _process_message
    handler(msg, send_reply)
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/dbus_next/message_bus.py", line 731, in handler
    result = method.fn(interface, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/bless/backends/bluezdbus/dbus/characteristic.py", line 142, in WriteValue
    f(self, value)
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/bless/backends/bluezdbus/server.py", line 260, in write
    return self.write_request(char.UUID, bytearray(value))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/bless/backends/server.py", line 271, in write_request
    self.write_request_func(characteristic, value)
  File "/dev/shm/pyImprov/example.py", line 130, in write_request
    success = server.update_value(
              ^^^^^^^^^^^^^^^^^^^^
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/bless/backends/bluezdbus/server.py", line 220, in update_value
    cur_value: Any = bless_char.value
                     ^^^^^^^^^^^^^^^^
  File "/dev/shm/pyImprov/lib/python3.11/site-packages/bless/backends/bluezdbus/characteristic.py", line 109, in value
    return bytearray(self._value)
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'bytearray' object cannot be interpreted as an integer
```
</details>