### PR TITLE
Drop back to AUTHORIZED state when Wifi connection fails

### DIFF
--- a/improv.py
+++ b/improv.py
@@ -218,6 +218,7 @@ class ImprovProtocol:
                                     self.rpc_response = self.build_rpc_response(
                                         ImprovCommand.WIFI_SETTINGS, rpc_urls)
                                 else:
+                                    self.state = ImprovState.AUTHORIZED
                                     self.last_error = ImprovError.UNABLE_TO_CONNECT
                         else:
                             self.last_error = ImprovError.INVALID_RPC


### PR DESCRIPTION
When the WiFi callback fails the state was left in PROVISIONING which leads clients like Konfigurator to be unable to send WiFi credentials again. So given we couldn't be provisioning unless AUTHORIZED if the WiFi callback fails then set our state back to AUTHORIZED